### PR TITLE
fix(README): Remove parse-edi python package no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ https://michaelachrisco.github.io/Electronic-Interchange-Github-Resources/
 - [git-albertomarin/badX12](https://github.com/git-albertomarin/badX12) - A Python Library for parsing ANSI ASC X12 files.
 - [greasysock/CahasEDI-Core](https://github.com/greasysock/CahasEDI-Core) - Server/Client to AS2 messaging server for managing EDI partnerships and interpreting messages. 
 - [keironstoddart/edi-835-parser](https://github.com/keironstoddart/edi-835-parser) - A simple EDI 835 file format parser.
-- [lab/parse-edi](https://hiplab.mc.vanderbilt.edu/git/lab/parse-edi) - Configurable electronic data interchange (EDI) parser for Healthcare (x12 837 and 835).
 ### Swift
 - [kuyawa/EdiMapper](https://github.com/kuyawa/EdiMapper) - Convert EDI Documents to XML
 ### PHP


### PR DESCRIPTION
Remove parse-edi resource that no longer exists. 