### PR TITLE
Add github actions to workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/ruby:latest
-    steps:
-      - checkout
-      - run: gem install awesome_bot
-      - run: awesome_bot --allow-redirect README.md

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,24 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: gem install awesome_bot
+      - name: Verify all links are valid
+        run: awesome_bot --allow-redirect README.md
+


### PR DESCRIPTION
Observations: 

1. GH Actions are a bit more verbose, but looks to have the same operations as CircleCI. 
2. GH Actions are well documented within GHs own docs here: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby


